### PR TITLE
fix(menu): misc link fixes and sync destinations

### DIFF
--- a/_includes/menu.njk
+++ b/_includes/menu.njk
@@ -1,8 +1,5 @@
 <nav class="fixed top-[34px] inset-x-0 bottom-0 bg-gray-dark text-white py-4 lg:relative lg:inset-auto lg:bg-transparent lg:p-0 lg:opacity-100 lg:transform-none peer-checked/menu:opacity-100 peer-checked/menu:transform-none opacity-0 translate-x-full transition-[opacity,transform] overflow-y-auto lg:overflow-visible">
   <ul class="lg:flex lg:flex-row lg:border-l lg:border-l-white/10 lg:border-r lg:border-r-gray-dark">
-    <li>
-      <a href="/" class="link-nav">Plugins</a>
-    </li>
     <li class="dropdown">
       <a href="https://contribute.jquery.org/" class="link-nav">Contribute</a>
       <ul class="pl-4 lg:p-0">
@@ -27,30 +24,24 @@
       </ul>
     </li>
     <li>
-      <a href="https://js.foundation/events" class="link-nav">Events</a>
+      <a href="https://events.jquery.org/" class="link-nav">Events</a>
     </li>
     <li class="dropdown">
-      <a href="https://jquery.org/support/" class="link-nav">Support</a>
+      <a href="https://jquery.com/support/" class="link-nav">Support</a>
       <ul>
         <li>
           <a href="https://learn.jquery.com/" class="link-nav">Learning Center</a>
         </li>
         <li>
-          <a href="https://irc.jquery.org/" class="link-nav">IRC/Chat</a>
-        </li>
-        <li>
-          <a href="https://forum.jquery.com/" class="link-nav">Forums</a>
+          <a href="https://jquery.com/support/" class="link-nav">Chat</a>
         </li>
         <li>
           <a href="https://stackoverflow.com/tags/jquery/info" class="link-nav">Stack Overflow</a>
         </li>
-        <li>
-          <a href="https://jquery.org/support/" class="link-nav">Commercial Support</a>
-        </li>
       </ul>
     </li>
     <li class="dropdown">
-      <a href="https://openjsf.org/" class="link-nav">JS Foundation</a>
+      <a href="https://openjsf.org/" class="link-nav">OpenJS Foundation</a>
       <ul class="pl-4 lg:p-0">
         <li>
           <a href="https://openjsf.org/join" class="link-nav">Join</a>


### PR DESCRIPTION
* Update label from JSF to OpenJSF, follows-up 50cbaf8354.
* Update support/evenets links to match current jquery.com.
* Remove "Plugins" from global nav, since it's merely a self-link here and likely not to stay on the main sites.

Ref https://github.com/jquery/infrastructure-puppet/issues/29